### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/MLNETCrashCourse/01.IntroductionToMLNET/README.md
+++ b/MLNETCrashCourse/01.IntroductionToMLNET/README.md
@@ -16,7 +16,7 @@ If you are going to use Visual Studio Code you will need to follow these steps. 
 
 #### Visual Studio Code - C# Extension
 
-To debug a .NET Core application you will need to install the [C# extension for vscode](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) by [clicking here](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) and clicking on **Install**. 
+To debug a .NET Core application you will need to install the [C# extension for vscode](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) by [clicking here](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and clicking on **Install**.
 
 #### .NET Core SDK
 

--- a/style-transfer/README.md
+++ b/style-transfer/README.md
@@ -49,7 +49,7 @@ If you need a new Azure subscription, then there are a couple of options to get 
 We'll use VS Code to test our model using ML.NET. Install VS Code along the following packages in your local environment to run the sample project.
 
 1. Download Visual Studio Code from [https://code.visualstudio.com/download](https://code.visualstudio.com/download).
-1. Install the [C# Extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+1. Install the [C# Extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 You will also require the following libraries in order to run the code:
 


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp".